### PR TITLE
update unfocus to support react SSR websites

### DIFF
--- a/dist/unfocus.js
+++ b/dist/unfocus.js
@@ -1,4 +1,8 @@
 (function(document, window){
+	if (!document || !window) {
+		return;
+	}
+	
 	var styleText = '::-moz-focus-inner{border:0 !important;}:focus{outline: none !important;';
 	var unfocus_style = document.createElement('STYLE');
 


### PR DESCRIPTION
I currently use this in my `react` site by doing `import "unfocus"`. However, this wouldn't work in React sites that are rendered on the server, as `document` and `window` are `undefined`.

In this PR, I simply added a check to ensure they're both not `undefined`.